### PR TITLE
Fix/reaction sprites in keystone

### DIFF
--- a/design/reactions.css
+++ b/design/reactions.css
@@ -118,7 +118,7 @@ only screen and (max-device-width: 480px) {
     margin-right: 4px;
     line-height: 18px;
     vertical-align: bottom;
-    background-image: url('images/action-sprites.png');
+    background-image: url('images/action-sprites.png')!important;
     background-position: 16px 16px;
     background-repeat: no-repeat;
 }

--- a/design/reactions.css
+++ b/design/reactions.css
@@ -122,6 +122,9 @@ only screen and (max-device-width: 480px) {
     background-position: 16px 16px;
     background-repeat: no-repeat;
 }
+.ReactButton.Quote .ReactSprite.ReactQuote {
+    background-image: none!important;
+}
 input + .ReactSprite {
     vertical-align: middle;
 }


### PR DESCRIPTION
Keystone has a custom_css which adds !important to hide the .ReactSprite. Therefore the yaga reactions.css must include that !important, too.
As a side effect, the quote sprite which comes with the Bitch Editor gets also duplicated, which requires an additional ugly fix.