### PR TITLE
Remove label "Optional" below the Css Class field, since that is a required field

### DIFF
--- a/views/action/edit.php
+++ b/views/action/edit.php
@@ -67,10 +67,7 @@ echo $this->Form->errors();
     </li>
     <li class="form-group">
         <div class="label-wrap">
-            <?php
-            echo $this->Form->label('Css Class', 'CssClass');
-            echo wrap(Gdn::translate('Optional'), 'div', ['class' => 'info']);
-            ?>
+            <?php echo $this->Form->label('Css Class', 'CssClass'); ?>
         </div>
         <div class="input-wrap">
             <?php echo $this->Form->textBox('CssClass'); ?>


### PR DESCRIPTION
When editing/adding a reation, the "Css Class" field is titled with "Optional". But the field itself is required.

The "Optional" might have had another meaning since you can enter anything you like and use this in order to use a custom icon.